### PR TITLE
Add missing required fields to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -2,4 +2,7 @@ name=Jpzukin ST7735 Library
 version=0.1.0
 author=Stupiddog
 maintainer=Stupiddog
+sentence=For the ST7735 1.8" color TFT display.
+paragraph=
 category=Display
+url=https://github.com/jpzukin/Jpzukin_ST7735S_Library


### PR DESCRIPTION
When a required field is missing from library.properties the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format